### PR TITLE
Font path fix

### DIFF
--- a/_sass/1-tools/_ionicons.scss
+++ b/_sass/1-tools/_ionicons.scss
@@ -12,8 +12,8 @@
 */
 @font-face {
   font-family: "Ionicons";
-  src: url("../fonts/ionicons.eot?v=4.2.1");
-  src: url("../fonts/ionicons.eot?v=4.2.1#iefix") format("embedded-opentype"), url("../fonts/ionicons.woff2?v=4.2.1") format("woff2"), url("../fonts/ionicons.woff?v=4.2.1") format("woff"), url("../fonts/ionicons.ttf?v=4.2.1") format("truetype"), url("../fonts/ionicons.svg?v=4.2.1#Ionicons") format("svg");
+  src: url("/fonts/ionicons.eot?v=4.2.1");
+  src: url("/fonts/ionicons.eot?v=4.2.1#iefix") format("embedded-opentype"), url("/fonts/ionicons.woff2?v=4.2.1") format("woff2"), url("/fonts/ionicons.woff?v=4.2.1") format("woff"), url("/fonts/ionicons.ttf?v=4.2.1") format("truetype"), url("/fonts/ionicons.svg?v=4.2.1#Ionicons") format("svg");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
I just downloaded your great theme and I think that there's a bug at fonts path (not sure, not my area of expertise :_) ).

With relative paths, symbols only load at home page. As you go, for
example, to the second page, they won't load.